### PR TITLE
update mapnik-omnivore

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "colonel-mercator": "./bin/colonel-mercator"
   },
   "dependencies": {
-    "mapnik-omnivore": "^7.4.0",
+    "mapnik-omnivore": "^8.1.0",
     "minimist": "^1.1.0",
     "split": "^0.3.3"
   },


### PR DESCRIPTION
Updates mapnik-omnivore to `^8.1.0`, which brings in updated node-mapnik versions.

cc @virginiayung @dnomadb 
