### PR TITLE
move to mapbox namespace; upgrade mapnik-om

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "colonel-mercator",
+  "name": "@mapbox/colonel-mercator",
   "version": "1.0.0",
   "main": "./index",
   "engines": {
@@ -14,7 +14,7 @@
     "colonel-mercator": "./bin/colonel-mercator"
   },
   "dependencies": {
-    "@mapbox/mapnik-omnivore": "^8.2.0",
+    "@mapbox/mapnik-omnivore": "~8.4.0",
     "minimist": "^1.1.0",
     "split": "^0.3.3"
   },

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -84,7 +84,7 @@ tape('[CLI - resolution (4326)] Test gets correct resolution, snaps down with 0.
 tape('[CLI - resolution (4326)] Test gets correct resolution, snaps down with 0.5 threshold (finest resolution)', function(assert) {
     exec('node bin/colonel-mercator resolution test/fixtures/hires-mini.tif --snap 0.5', function(err, stdout, stderr) {
         assert.error(err, 'Should not error');
-        assert.looseEquals(stdout, 0.0373227521777153);
+        assert.looseEquals(stdout, 0.01866137608885765);
         assert.end();
     })
 });

--- a/test/lib.test.js
+++ b/test/lib.test.js
@@ -78,7 +78,7 @@ tape('[LIB - get resolution] Test gets correct above highest cellsize, snaps', f
     var snapping = 0.5;
     merc_res.get_resolution(metadata, maxRes, snapping, function(err, res) {
         assert.error(err);
-        assert.deepLooseEqual(res, [ 0.0373227521777153, 0.0373227521777153 ])
+        assert.deepLooseEqual(res, [ 0.01866137608885765, 0.01866137608885765 ])
         assert.end();
     });
 });


### PR DESCRIPTION
Fixes #16 
- Moves to `@mapbox` namespace
- Bumps `mapnik-omnivore` to version w/ mapnik 3.6.0, w/ ~ prefix

cc @perrygeo